### PR TITLE
fix(rpc): digest.write must not take an external key that already exists

### DIFF
--- a/crates/dr-strange-web/src/methods.rs
+++ b/crates/dr-strange-web/src/methods.rs
@@ -5,6 +5,7 @@
 //! wire shape. Most methods are reads; `digest.run`/`digest.write` power the
 //! digest page (arch/07), the latter writing through the bulk path.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use dr_strange_core::{
@@ -1519,12 +1520,41 @@ pub fn digest_write(ctx: &Ctx<'_>, p: Value) -> Result<Value, RpcError> {
     let req: DigestWrite = params(p)?;
     let plane = app(ctx.db.plane(&req.plane))?;
 
-    let mut node_props = Vec::with_capacity(req.nodes.len());
+    // Only nodes whose key is genuinely free get written.
+    //
+    // `bulk_load` writes the external-key index unconditionally: a proposed key
+    // that already exists overwrites the index entry, leaving the original node
+    // in place but reachable only by id. Every `key(...)` read against it then
+    // returns empty while the data sits there untouched. Observed, not
+    // theorised: one run shadowed two nodes an application addressed by key,
+    // and every key-filtered read for them went empty at the same moment —
+    // no error, no log line. `node.create` has always rejected a taken key;
+    // this path was the way around it.
+    //
+    // Skipping rather than failing the batch: a distillation proposes every
+    // entity as new (`link: false`), so naming something already known is the
+    // normal case, not an error — rejecting the batch would drop the run
+    // exactly when it had learned something. Edges are kept either way:
+    // `resolve` falls back to the plane's existing keys, so an edge onto a
+    // skipped key attaches to the node that was already there, which is what
+    // "this distillation mentions something we know" ought to mean.
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut fresh: Vec<&WriteNode> = Vec::with_capacity(req.nodes.len());
+    let mut skipped: Vec<&str> = Vec::new();
     for n in &req.nodes {
+        // Intra-batch duplicates would make bulk_load reject the whole call.
+        if !seen.insert(n.key.as_str()) || app(plane.node_by_key(&n.key))?.is_some() {
+            skipped.push(n.key.as_str());
+            continue;
+        }
+        fresh.push(n);
+    }
+
+    let mut node_props = Vec::with_capacity(fresh.len());
+    for n in &fresh {
         node_props.push(props_of(&n.properties)?);
     }
-    let label_slots: Vec<[&str; 1]> = req
-        .nodes
+    let label_slots: Vec<[&str; 1]> = fresh
         .iter()
         .map(|n| {
             [if n.label.is_empty() {
@@ -1534,8 +1564,7 @@ pub fn digest_write(ctx: &Ctx<'_>, p: Value) -> Result<Value, RpcError> {
             }]
         })
         .collect();
-    let bnodes: Vec<BulkNode> = req
-        .nodes
+    let bnodes: Vec<BulkNode> = fresh
         .iter()
         .zip(&label_slots)
         .zip(node_props)
@@ -1565,7 +1594,14 @@ pub fn digest_write(ctx: &Ctx<'_>, p: Value) -> Result<Value, RpcError> {
     let mut txn = app(plane.write())?;
     let stats = app(txn.bulk_load(bnodes, bedges))?;
     app(txn.commit())?;
-    Ok(jval!({ "nodes_written": stats.nodes, "edges_written": stats.edges }))
+    // `skipped_keys` is reported, not just counted: a silent skip is how the
+    // client-side guard managed to do nothing for weeks without anyone noticing.
+    Ok(jval!({
+        "nodes_written": stats.nodes,
+        "edges_written": stats.edges,
+        "nodes_skipped": skipped.len(),
+        "skipped_keys": skipped,
+    }))
 }
 
 // ---- granular mutations (arch/09 §3) --------------------------------------

--- a/crates/dr-strange-web/tests/http.rs
+++ b/crates/dr-strange-web/tests/http.rs
@@ -250,3 +250,96 @@ async fn auth_gate_over_http() {
     let forbidden_read = post(read, Some("https://evil.example.com")).await.unwrap();
     assert_eq!(forbidden_read.status(), reqwest::StatusCode::FORBIDDEN);
 }
+
+/// `digest.write` must never take a key that is already bound in the plane.
+///
+/// It writes through the bulk path, which stamps the external-key index
+/// unconditionally — so before this was gated, a proposal naming an existing
+/// entity overwrote that index entry and left the original node reachable only
+/// by id. Every `key(...)` read against it then came back empty while the data
+/// sat there untouched — observed in practice, on nodes an application
+/// addressed by key, with no error and no log line to notice it by.
+///
+/// Skipping is the contract, not failing: a distillation proposes every entity
+/// as new, so naming something already known is the normal case. The edge is
+/// still written and must land on the *original* node.
+#[tokio::test]
+async fn digest_write_never_shadows_an_existing_key() {
+    let addr = spawn_server();
+    let base = format!("http://{addr}");
+    let client = reqwest::Client::new();
+    wait_ready(&client, &base).await;
+
+    let created = rpc(
+        &client,
+        &base,
+        "node.create",
+        json!({ "plane": "startup", "key": "proj", "labels": ["Project"],
+                "properties": { "path": "/keep/me" } }),
+    )
+    .await;
+    let original = created["result"]["id"].as_u64().unwrap();
+
+    // A proposal that re-proposes `proj`, names it twice, and hangs a new node
+    // off it — exactly the shape digest.run emits with `link: false`.
+    let w = rpc(
+        &client,
+        &base,
+        "digest.write",
+        json!({
+            "plane": "startup",
+            "nodes": [
+                { "key": "proj",  "label": "Project", "properties": { "path": "/overwritten" } },
+                { "key": "proj",  "label": "Project", "properties": {} },
+                { "key": "fresh", "label": "Note",    "properties": {} }
+            ],
+            "edges": [ { "src": "fresh", "dst": "proj", "type": "ABOUT" } ],
+        }),
+    )
+    .await["result"]
+        .clone();
+
+    assert_eq!(
+        w["nodes_written"], 1,
+        "only the genuinely new node is written"
+    );
+    assert_eq!(w["nodes_skipped"], 2, "the taken key, twice over");
+    assert_eq!(
+        w["skipped_keys"],
+        json!(["proj", "proj"]),
+        "skips are reported, not silent"
+    );
+    assert_eq!(w["edges_written"], 1, "the edge still lands");
+
+    // The key still resolves to the node that owned it, properties intact.
+    let got = rpc(
+        &client,
+        &base,
+        "node.get",
+        json!({ "plane": "startup", "key": "proj" }),
+    )
+    .await;
+    assert_eq!(got["result"]["id"], original, "key must not have moved");
+    assert_eq!(
+        got["result"]["properties"]["path"], "/keep/me",
+        "not overwritten"
+    );
+
+    // …and the edge attached to that original node, not to a second one.
+    let n = rpc(
+        &client,
+        &base,
+        "plane.cypher",
+        json!({
+            "plane": "startup",
+            "query": "MATCH (p:Project)<-[:ABOUT]-(x) WHERE key(p) = $k RETURN x",
+            "params": { "k": "proj" },
+        }),
+    )
+    .await;
+    assert_eq!(
+        n["result"]["nodes"].as_array().unwrap().len(),
+        1,
+        "edge onto a skipped key must resolve to the node already there"
+    );
+}


### PR DESCRIPTION
## Problem

`digest.write` writes through `bulk_load`, which stamps the external-key index
unconditionally. A proposal naming an entity already in the plane therefore
**repoints that index entry at a brand-new node**. The original is not
overwritten — it keeps its properties, its labels and all its edges — it simply
stops being reachable by key:

| | after the collision |
|---|---|
| original node record | intact, under its old id |
| its label-index entries | intact — a label scan still returns it |
| its edges | intact (adjacency is keyed by node id) |
| `ext_key(plane, k)` | **now points at the new, empty node** |

So `node_by_key(k)` and `key(n) = k` resolve to the new node, a traversal from
it finds nothing (its adjacency prefix is empty), and a label scan returns
*both*. No error, no log line, nothing to notice — the data is all still there,
only the name no longer reaches it.

Observed in practice: one run wrote five duplicate keys, two of them shadowing
nodes an application addressed by key, and every key-filtered read for those
went empty at the same moment.

## The invariant already exists — the bulk path just doesn't get it

`insert_node` carries the uniqueness check, and its doc comment states the
intended scope explicitly:

> The external-key uniqueness check lives *here*, not only in
> `create_node_with_key`, so **every entry point (including the batched path)
> gets it** — a second node silently sharing a key would desync the key from
> the reverse index it's supposed to name.

But `bulk_load` does not go through `insert_node`. `stage_nodes` encodes the
node record itself and `put_batch`es it, so that guard never runs on this path.
The failure the comment predicts — "desync the key from the reverse index it's
supposed to name" — is exactly the one above.

Worth noting: `stage_nodes` *does* reject duplicates **within** a batch
(`Error::Conflict`), just not keys already present in the plane. One half of
the check is there.

## Fix

`digest_write` now probes each proposed key and passes only genuinely free ones
to `bulk_load`. Three choices worth calling out:

- **Skip, don't fail the batch.** A distillation proposes every entity as new
  (`link: false`), so naming something already known is the normal case, not an
  error. Rejecting the batch would drop the run precisely when it had learned
  something.
- **Keep the edges.** `resolve` checks the staged batch first, then falls back
  to the plane's existing keys — and `staged.write` happens *after* edge
  resolution, so an edge onto a skipped key attaches to the node that was
  already there. That is what "this document mentions something we know" ought
  to mean.
- **Report `skipped_keys`, don't just count them.** A silent skip is how a
  client-side version of this same guard managed to do nothing at all,
  undetected, for weeks.

Intra-batch duplicates are dropped too, since `bulk_load` would otherwise
reject the whole call.

## Where should the guard live?

I put it in `digest_write` rather than in `bulk_load`, on the assumption that
`bulk_load` is deliberately the trusted fast path (the CLI importer validates
against its own in-memory node set before calling it) and that adding a lookup
per node there would cost import throughput.

That leaves the documented invariant still unenforced for any future caller of
the bulk path. If you'd rather have the check in core — or a
`bulk_load_checked` variant — I'm happy to move it; this is your call on the
layering.

## Test plan

- New `digest_write_never_shadows_an_existing_key` (HTTP integration): creates
  `proj`, then posts a proposal that re-proposes `proj` twice and hangs a new
  node off it. Asserts 1 written / 2 skipped, `skipped_keys` reported, the key
  still resolves to the **original** id with properties intact, and the edge
  landed on that original node.
- `cargo test -p dr-strange-web` — 120 passed
- `RUSTFLAGS=-D warnings cargo clippy -p dr-strange-web --all-targets` — clean
- `cargo fmt --all --check` — clean
