### PR TITLE
feat(llm): optional reasoning_effort on chat completions

### DIFF
--- a/crates/dr-strange-llm/src/openai.rs
+++ b/crates/dr-strange-llm/src/openai.rs
@@ -20,6 +20,11 @@ use crate::provider::{Chat, ChatReply, EmbedReply, Embedder, OutputTruncated};
 /// JSON is not cut off mid-object (which yields unparseable output). Chunks are
 /// size-bounded upstream, so this is rarely the binding limit; it also fits the
 /// preset models' output caps (deepseek-chat / qwen-plus are 8K).
+///
+/// Reasoning models (e.g. DeepSeek-v4-flash) are handled by `reasoning_effort:
+/// "none"` in [`Chat::complete`], not by shrinking this — their thinking tokens
+/// used to fill 8192 and truncate the JSON, but disabling reasoning keeps the
+/// output to clean structured JSON well under any of these caps.
 const MAX_OUTPUT_TOKENS: u32 = 8192;
 
 /// Ceiling on one provider round-trip. Long enough for a slow model writing a
@@ -95,6 +100,12 @@ pub struct OpenAiProvider {
     /// Max texts per embeddings request. OpenAI accepts large batches; some
     /// providers (DashScope/Qwen) cap it, so it's configurable.
     embed_batch: usize,
+    /// Optional `reasoning_effort` sent on chat completions. Reasoning models
+    /// (e.g. DeepSeek-v4-flash) emit long thinking tokens that fill the output
+    /// cap and truncate the structured JSON dr-strange needs; setting this to
+    /// "none" disables them. `None` (the default) sends nothing, keeping
+    /// behavior unchanged for providers that don't need it.
+    reasoning_effort: Option<String>,
 }
 
 impl OpenAiProvider {
@@ -108,12 +119,20 @@ impl OpenAiProvider {
             api_key: api_key.into(),
             model: model.into(),
             embed_batch: 256,
+            reasoning_effort: None,
         }
     }
 
     /// Cap embeddings requests at `n` texts each (default 256).
     pub fn with_embed_batch(mut self, n: usize) -> Self {
         self.embed_batch = n.max(1);
+        self
+    }
+
+    /// Set the `reasoning_effort` sent on chat completions ("none" disables
+    /// reasoning for models like DeepSeek-v4-flash). Default: not sent.
+    pub fn with_reasoning_effort(mut self, effort: impl Into<String>) -> Self {
+        self.reasoning_effort = Some(effort.into());
         self
     }
 
@@ -207,20 +226,34 @@ impl OpenAiProvider {
     }
 }
 
+impl OpenAiProvider {
+    /// The `chat/completions` request body. Split out from [`Chat::complete`]
+    /// so the optional-field logic is assertable without a provider on the
+    /// other end of a socket.
+    fn chat_body(&self, system: &str, user: &str) -> Value {
+        let mut body = json!({
+            "model": self.model,
+            "temperature": 0,
+            "max_tokens": MAX_OUTPUT_TOKENS,
+            "messages": [
+                { "role": "system", "content": system },
+                { "role": "user", "content": user },
+            ],
+        });
+        // Reasoning models (e.g. DeepSeek-v4-flash) emit long thinking tokens
+        // that fill the output cap and truncate the structured JSON dr-strange
+        // needs. `with_reasoning_effort("none")` opts into disabling them; when
+        // unset we send nothing and keep the provider's default behavior.
+        if let Some(effort) = &self.reasoning_effort {
+            body["reasoning_effort"] = Value::String(effort.clone());
+        }
+        body
+    }
+}
+
 impl Chat for OpenAiProvider {
     fn complete(&self, system: &str, user: &str) -> Result<ChatReply> {
-        let v = self.post(
-            "chat/completions",
-            json!({
-                "model": self.model,
-                "temperature": 0,
-                "max_tokens": MAX_OUTPUT_TOKENS,
-                "messages": [
-                    { "role": "system", "content": system },
-                    { "role": "user", "content": user },
-                ],
-            }),
-        )?;
+        let v = self.post("chat/completions", self.chat_body(system, user))?;
         let choice = &v["choices"][0];
         // A truncated reply (hit the output cap) is unparseable JSON — surface
         // the real cause instead of a confusing "not valid extraction JSON".
@@ -278,6 +311,24 @@ mod tests {
         for s in [400, 401, 403, 404, 422] {
             assert!(!worth_retrying(s), "{s} must not be retried");
         }
+    }
+
+    #[test]
+    fn reasoning_effort_is_sent_only_when_asked_for() {
+        let p = OpenAiProvider::new("http://example.invalid/v1", "k", "m");
+        // Unset is not the same as "none": a provider that has no such field
+        // must see no such field, or every non-reasoning model gets a request
+        // it did not have before.
+        assert!(p.chat_body("s", "u").get("reasoning_effort").is_none());
+
+        let p = p.with_reasoning_effort("none");
+        assert_eq!(p.chat_body("s", "u")["reasoning_effort"], json!("none"));
+        // The rest of the body is untouched by the option.
+        assert_eq!(
+            p.chat_body("s", "u")["max_tokens"],
+            json!(MAX_OUTPUT_TOKENS)
+        );
+        assert_eq!(p.chat_body("s", "u")["messages"][1]["content"], json!("u"));
     }
 
     #[test]

--- a/crates/dr-strange-web/src/methods.rs
+++ b/crates/dr-strange-web/src/methods.rs
@@ -1378,6 +1378,12 @@ pub struct DigestRun {
     model: Option<String>,
     #[serde(default)]
     embed_model: Option<String>,
+    /// `reasoning_effort` to send on the extraction chat calls (e.g. `"none"`
+    /// to disable reasoning on models that would otherwise spend the output
+    /// budget on thinking tokens and truncate the extraction JSON). Unset ⇒
+    /// not sent, so the provider's own default applies.
+    #[serde(default)]
+    reasoning_effort: Option<String>,
     #[serde(default)]
     source: Option<String>,
     #[serde(default)]
@@ -1415,6 +1421,13 @@ pub fn digest_run(ctx: &Ctx<'_>, p: Value) -> Result<Value, RpcError> {
     let chat =
         dr_strange_llm::build_provider(chat_provider, req.model.as_deref(), None, None, false)
             .map_err(llm_err)?;
+    // Opt-in only: unset leaves the request body byte-for-byte what it was, so
+    // providers with no such field are unaffected. Embedding calls never carry
+    // it — there is nothing to reason about.
+    let chat = match req.reasoning_effort.as_deref() {
+        Some(effort) => chat.with_reasoning_effort(effort),
+        None => chat,
+    };
     let chat_model = chat.model().to_string();
     let embedder = dr_strange_llm::build_provider(
         embed_provider,


### PR DESCRIPTION
## Problem

A reasoning model can spend the whole output budget on thinking tokens and
truncate the extraction JSON mid-object. The reply then fails as "not valid
extraction JSON" — and digest's recovery path makes it worse rather than
better.

`extract_chunk` responds to `OutputTruncated` by halving the chunk and
retrying. That is the right move when the *input* was too long: halve the
input, halve the output. But thinking length does not shrink with the input,
so each half truncates again, and the retries fan out — 1 → 2 → 4 → 8 calls,
each paying full reasoning cost — until the text can no longer be divided and
the error surfaces anyway.

Raising `MAX_OUTPUT_TOKENS` is not the fix: thinking length has no upper bound
you control, and 8192 already sits at the output ceiling of the preset models
(deepseek-chat / qwen-plus).

## Fix

`reasoning_effort: "none"` removes the cause where the provider understands
the field.

- An optional `reasoning_effort` on `OpenAiProvider`, set through
  `with_reasoning_effort()` and sent **only when set**. Unset is not the same
  as `"none"`: a provider with no such field must see no such field, or every
  non-reasoning model starts getting a request body it did not have before.
  The new test pins both directions.
- The request body moves into `chat_body()` so the optional-field logic is
  assertable without a provider on the other end of a socket.
- `digest.run` gains a `reasoning_effort` param, forwarded to the chat
  provider only — embedding calls never carry it.

## Note on scope

The value is passed through verbatim; valid values are the provider's to
define (OpenAI currently: `none` / `minimal` / `low` / `medium` / `high`).
Validating a set here would go stale the moment a provider adds a level.

## Test plan

- New `reasoning_effort_is_sent_only_when_asked_for` — asserts absence when
  unset, `"none"` when set, and that `max_tokens` / `messages` are untouched
  either way
- `cargo test -p dr-strange-llm` — 46 passed
- `cargo test -p dr-strange-web` — 119 passed
- `RUSTFLAGS=-D warnings cargo clippy -p dr-strange-llm -p dr-strange-web --all-targets` — clean
- `cargo fmt --all --check` — clean
