### PR TITLE
feat(rpc): let digest.run reach any OpenAI-compatible endpoint

### DIFF
--- a/crates/dr-strange-web/src/methods.rs
+++ b/crates/dr-strange-web/src/methods.rs
@@ -1363,6 +1363,26 @@ fn llm_err(e: anyhow::Error) -> RpcError {
     RpcError::server(e.to_string())
 }
 
+/// Build an LLM provider from a `chat`/`embed` spec: either a preset name
+/// (`openai`, `deepseek`, `qwen`, `ollama`) or a raw base URL to any
+/// OpenAI-compatible endpoint. `key_env` names the environment variable the
+/// server reads the key from — the key itself never travels in params; for a
+/// preset it defaults to that preset's own key env, as before.
+fn build_provider_flexible(
+    spec: &str,
+    model: Option<&str>,
+    key_env: Option<&str>,
+    embed: bool,
+) -> Result<dr_strange_llm::OpenAiProvider, RpcError> {
+    if spec.contains("://") {
+        // A raw base URL: empty preset name + explicit url. `build_provider`
+        // falls back to the url when the preset resolves to None.
+        dr_strange_llm::build_provider("", model, Some(spec), key_env, embed).map_err(llm_err)
+    } else {
+        dr_strange_llm::build_provider(spec, model, None, key_env, embed).map_err(llm_err)
+    }
+}
+
 #[derive(Deserialize)]
 pub struct DigestRun {
     /// Target plane — only read here, to retrieve existing entities as reuse
@@ -1370,14 +1390,26 @@ pub struct DigestRun {
     plane: String,
     /// The document text to digest.
     text: String,
+    /// Chat provider: a preset name (openai/deepseek/qwen/ollama) or a raw
+    /// base URL to any OpenAI-compatible endpoint (default `openai`).
     #[serde(default)]
     chat: Option<String>,
+    /// Embedding provider: preset name or base URL (defaults to `chat`).
     #[serde(default)]
     embed: Option<String>,
     #[serde(default)]
     model: Option<String>,
     #[serde(default)]
     embed_model: Option<String>,
+    /// Name of the environment variable holding the chat API key. For a preset
+    /// this defaults to that preset's own key env; for a raw base URL it is
+    /// required when the endpoint needs a key. The key itself never travels in
+    /// params — only the name of the variable the server reads it from.
+    #[serde(default)]
+    key_env: Option<String>,
+    /// The same, for the embedding provider.
+    #[serde(default)]
+    embed_key_env: Option<String>,
     #[serde(default)]
     source: Option<String>,
     #[serde(default)]
@@ -1412,18 +1444,19 @@ pub fn digest_run(ctx: &Ctx<'_>, p: Value) -> Result<Value, RpcError> {
     let embed = !req.no_embed;
     let link = req.link.unwrap_or(true);
 
-    let chat =
-        dr_strange_llm::build_provider(chat_provider, req.model.as_deref(), None, None, false)
-            .map_err(llm_err)?;
+    let chat = build_provider_flexible(
+        chat_provider,
+        req.model.as_deref(),
+        req.key_env.as_deref(),
+        false,
+    )?;
     let chat_model = chat.model().to_string();
-    let embedder = dr_strange_llm::build_provider(
+    let embedder = build_provider_flexible(
         embed_provider,
         req.embed_model.as_deref(),
-        None,
-        None,
+        req.embed_key_env.as_deref(),
         embed,
-    )
-    .map_err(llm_err)?;
+    )?;
 
     let opts = dr_strange_llm::DigestOptions {
         source: req.source.unwrap_or_else(|| "web-digest".into()),


### PR DESCRIPTION
## Problem

`build_provider` already accepts a base URL and a key-env name, and the CLI
passes both. `digest.run` passed `None` for each:

```rust
build_provider(chat_provider, req.model.as_deref(), None, None, false)
//                                                  ^url  ^key_env
```

With `url = None` the base can only come from a preset, so any name outside
the four presets fails with

```
unknown provider '<name>'; give a base URL instead
```

— advice the RPC surface gave no way to follow. The same binary could reach an
arbitrary OpenAI-compatible endpoint from the command line and only
`openai` / `deepseek` / `qwen` / `ollama` over RPC.

`key_env = None` is the matching half: with no preset there is no default key
env, so the key resolves to empty and the request goes out unauthenticated.
Both parameters have to be filled for either to be useful.

Concretely this shut out self-hosted and proxied endpoints (vLLM, LiteLLM,
gateways), OpenAI-compatible vendors outside the preset list, an Ollama on any
host other than localhost, and the `dashscope-intl` host that `preset.rs`'s
own comment tells non-mainland users to switch to via `--embed-url` — a flag
that exists only on the CLI.

## Fix

- `build_provider_flexible`: `chat` / `embed` take a preset name as before, or
  a raw base URL (anything containing `://`).
- `DigestRun` gains `key_env` / `embed_key_env` — the **name** of the
  environment variable the server reads the key from. The key itself still
  never travels in params, which is the property `digest_run`'s doc comment
  already promises ("Provider API keys come from the server's environment,
  never params"). For a preset the name defaults to that preset's own,
  unchanged.

No behavior change for existing callers: a preset name takes exactly the path
it took before.

## Scope

This fixes the `digest.run` call sites in `dr-strange-web` only. The same
`None, None` pattern appears six more times in `dr-strange-mcp`, and it is not
limited to ingestion — it gates anything that has to turn text into a vector:

| | |
|---|---|
| `hybrid_logic` (lib.rs:614) | the `hybrid` tool's vector channel |
| `ask_logic` (lib.rs:665, 667) | the `ask` tool, chat and embed both |
| `cypher_logic` (lib.rs:746) | `SEARCH … NEAR "text"` in the `cypher` tool |
| `digest_logic` (lib.rs:846, 848) | the `digest` tool |

So an agent on the MCP surface is held to the same four presets for most of
the retrieval surface, not just for digest.

I left those out deliberately — folding them in would turn this from "fill in
two arguments at one call site" into "rework provider resolution across a
crate", and the two deserve separate review. Happy to follow up with that PR
if you'd like it, in whatever shape you prefer.

Worth noting while weighing it: "just use the CLI" is not a workaround in a
server deployment. `Command::Digest` opens the database (`main.rs:609`), and
the native backend allows one process per database — so with `drsg serve`
running, the CLI cannot touch the same database without stopping the server
first.

## Test plan

- `cargo test -p dr-strange-web` — 119 passed
- `RUSTFLAGS=-D warnings cargo clippy -p dr-strange-web --all-targets` — clean
- `cargo fmt --all --check` — clean

Touches the same lines of `digest_run` as #7; whichever lands second needs a
trivial rebase.
