### PR TITLE
fix(llm): honour the documented "a provider name may be a base URL" contract

### DIFF
--- a/crates/dr-strange-llm/src/openai.rs
+++ b/crates/dr-strange-llm/src/openai.rs
@@ -54,10 +54,21 @@ fn backoff(attempt: u32) -> Duration {
         .min(MAX_BACKOFF)
 }
 
+/// A provider name that is a base URL rather than a preset. Scheme-bearing is
+/// the whole test: preset names are bare words, and anything else was already
+/// an error, so this cannot reclassify a name that used to resolve.
+fn looks_like_url(provider: &str) -> bool {
+    provider.contains("://")
+}
+
 /// Build an [`OpenAiProvider`] from a provider name (a [`preset`] or a raw base
 /// URL) plus optional overrides, reading the API key from the environment. The
 /// one place CLI and MCP resolve provider config the same way. `embed` selects
 /// the embedding vs chat default model and, when true, requires a model.
+///
+/// A raw base URL has no preset behind it, so it carries no default key env and
+/// no default model: pass `key_env` when the endpoint needs a key, and `model`
+/// (always, for embeddings — an empty embedding model is rejected below).
 pub fn build_provider(
     provider: &str,
     model: Option<&str>,
@@ -69,6 +80,15 @@ pub fn build_provider(
     let base = url
         .map(str::to_string)
         .or_else(|| p.map(|p| p.base_url.to_string()))
+        // The name itself may be the base URL — what this function's own doc
+        // line and [`preset`]'s ("the caller then treats it as a raw base URL")
+        // have always said, and what the CLI help and the MCP tool schemas
+        // advertise. Only the explicit `url` override implemented it, so every
+        // caller that had no such override — `drsg ask`, query-time embedding,
+        // `digest.run` over RPC, and the MCP tools — answered a URL with
+        // "unknown provider ...; give a base URL instead", advice those
+        // surfaces gave no way to follow.
+        .or_else(|| looks_like_url(provider).then(|| provider.to_string()))
         .ok_or_else(|| anyhow!("unknown provider '{provider}'; give a base URL instead"))?;
     let key_env = key_env.or_else(|| p.map(|p| p.key_env)).unwrap_or("");
     let key = if key_env.is_empty() {
@@ -288,6 +308,56 @@ mod tests {
         // However many attempts a future change allows, the wait stays bounded.
         assert_eq!(backoff(50), MAX_BACKOFF);
         assert!(backoff(4) <= MAX_BACKOFF);
+    }
+
+    #[test]
+    fn a_provider_name_that_is_a_url_becomes_the_base_url() {
+        // The contract the doc line above has always stated. Every caller with
+        // no explicit `url` override depends on it: `drsg ask`, query-time
+        // embedding, `digest.run` over RPC, and the MCP tools.
+        let p = build_provider("http://127.0.0.1:1234/v1", Some("m"), None, None, false).unwrap();
+        assert_eq!(p.base_url, "http://127.0.0.1:1234/v1");
+        assert_eq!(p.model(), "m");
+        // No preset behind it, so no key env is invented and no key is read.
+        assert_eq!(p.api_key, "");
+    }
+
+    #[test]
+    fn presets_and_explicit_urls_keep_precedence() {
+        // A preset name resolves to the preset exactly as before.
+        let p = build_provider("openai", None, None, None, false).unwrap();
+        assert_eq!(p.base_url, "https://api.openai.com/v1");
+        assert_eq!(p.model(), "gpt-4o-mini");
+        // An explicit `url` still wins over a URL-shaped name.
+        let p = build_provider(
+            "http://name/v1",
+            Some("m"),
+            Some("http://override/v1"),
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(p.base_url, "http://override/v1");
+    }
+
+    #[test]
+    fn a_bare_unknown_name_is_still_an_error() {
+        // Carrying a scheme is the whole test, so a mistyped preset keeps its
+        // error instead of being taken for a hostname.
+        let Err(e) = build_provider("opanai", None, None, None, false) else {
+            panic!("a bare unknown name must not resolve to a provider");
+        };
+        assert!(e.to_string().contains("unknown provider"), "{e}");
+    }
+
+    #[test]
+    fn a_url_provider_still_needs_an_embedding_model() {
+        // A preset supplies a default embedding model; a bare URL cannot, so
+        // the existing guard has to fire rather than send an empty model.
+        let Err(e) = build_provider("http://127.0.0.1:1234/v1", None, None, None, true) else {
+            panic!("an embedding provider with no model must be rejected");
+        };
+        assert!(e.to_string().contains("no embedding model"), "{e}");
     }
 
     /// A one-connection-at-a-time HTTP server that answers with each of

--- a/crates/dr-strange-mcp/src/lib.rs
+++ b/crates/dr-strange-mcp/src/lib.rs
@@ -204,6 +204,11 @@ struct Hybrid {
     /// Embedding provider for the vector channel (key from the server env).
     #[serde(default)]
     provider: Option<String>,
+    /// Name of the environment variable the server reads the provider key
+    /// from. A preset defaults to its own; a base URL has none, so name it
+    /// here when the endpoint needs a key. The key never travels in params.
+    #[serde(default)]
+    key_env: Option<String>,
     #[serde(default)]
     embed_model: Option<String>,
 }
@@ -226,12 +231,20 @@ struct Ask {
     /// Chat provider (preset or base URL); key from the server env.
     #[serde(default)]
     provider: Option<String>,
+    /// Name of the environment variable the server reads the chat key from. A
+    /// preset defaults to its own; a base URL has none, so name it here when
+    /// the endpoint needs a key. The key never travels in params.
+    #[serde(default)]
+    key_env: Option<String>,
     #[serde(default)]
     model: Option<String>,
     /// Embedding provider for the find_edge/find_entity grounding tools (should
     /// match how the plane was embedded). Omit to disable them (schema only).
     #[serde(default)]
     embed_provider: Option<String>,
+    /// The same, for the embedding provider.
+    #[serde(default)]
+    embed_key_env: Option<String>,
     #[serde(default)]
     embed_model: Option<String>,
 }
@@ -253,6 +266,14 @@ struct Digest {
     /// Embedding provider preset or base URL (defaults to the chat provider).
     #[serde(default)]
     embed: Option<String>,
+    /// Name of the environment variable the server reads the chat key from. A
+    /// preset defaults to its own; a base URL has none, so name it here when
+    /// the endpoint needs a key. The key never travels in params.
+    #[serde(default)]
+    key_env: Option<String>,
+    /// The same, for the embedding provider.
+    #[serde(default)]
+    embed_key_env: Option<String>,
     /// Chat model override.
     #[serde(default)]
     model: Option<String>,
@@ -328,6 +349,15 @@ struct Cypher {
     /// the server environment supplies the key. Defaults to `openai`.
     #[serde(default)]
     embed: Option<String>,
+    /// Name of the environment variable the server reads the embedding key
+    /// from. A preset defaults to its own; a base URL has none, so name it
+    /// here when the endpoint needs a key. The key never travels in params.
+    #[serde(default)]
+    embed_key_env: Option<String>,
+    /// Embedding model. A preset supplies its own; a base URL has none, so it
+    /// is required there for a text `SEARCH … NEAR "…"`.
+    #[serde(default)]
+    embed_model: Option<String>,
     /// Values for `$name` placeholders in the query, e.g. `{"min": 18}`.
     #[serde(default)]
     params: serde_json::Map<String, Value>,
@@ -615,7 +645,7 @@ fn hybrid_logic(db: &Database, req: Hybrid) -> AnyResult<Value> {
             provider,
             req.embed_model.as_deref(),
             None,
-            None,
+            req.key_env.as_deref(),
             true,
         )?);
         let reply = embedder.embed(std::slice::from_ref(&req.query))?;
@@ -662,9 +692,22 @@ fn hybrid_logic(db: &Database, req: Hybrid) -> AnyResult<Value> {
 fn ask_logic(db: &Database, req: Ask) -> AnyResult<Value> {
     let plane = db.plane(&req.plane)?;
     let provider = req.provider.as_deref().unwrap_or("openai");
-    let chat = dr_strange_llm::build_provider(provider, req.model.as_deref(), None, None, false)?;
+    let chat = dr_strange_llm::build_provider(
+        provider,
+        req.model.as_deref(),
+        None,
+        req.key_env.as_deref(),
+        false,
+    )?;
     let embedder = req.embed_provider.as_deref().and_then(|ep| {
-        dr_strange_llm::build_provider(ep, req.embed_model.as_deref(), None, None, true).ok()
+        dr_strange_llm::build_provider(
+            ep,
+            req.embed_model.as_deref(),
+            None,
+            req.embed_key_env.as_deref(),
+            true,
+        )
+        .ok()
     });
     let opts = dr_strange_llm::AskOptions {
         max_attempts: req.max_attempts.unwrap_or(20),
@@ -743,9 +786,21 @@ fn pin(p: PlaneHandle<'_>, at: Option<dr_strange_parser::AsOfSpec>) -> AnyResult
 
 fn cypher_logic(db: &Database, req: Cypher) -> AnyResult<Value> {
     let provider = req.embed.as_deref().unwrap_or("openai");
-    let embedder = dr_strange_llm::build_provider(provider, None, None, None, true)
-        .ok()
-        .map(|p| LlmEmbedder(Box::new(p)));
+    // Built eagerly because the parser needs it up front, but tolerantly: most
+    // queries never embed anything, and a plain MATCH must not require a
+    // provider. The reason is kept rather than dropped — without it a query
+    // that *does* need an embedder reports only "needs an embedding provider
+    // (set the API key)", which misdirects when the real cause was the
+    // provider spec (an unusable base URL, or a model the endpoint requires).
+    let built = dr_strange_llm::build_provider(
+        provider,
+        req.embed_model.as_deref(),
+        None,
+        req.embed_key_env.as_deref(),
+        true,
+    );
+    let why_no_embedder = built.as_ref().err().map(|e| e.to_string());
+    let embedder = built.ok().map(|p| LlmEmbedder(Box::new(p)));
     // Resolve `$name` placeholders from the params object.
     let mut params = dr_strange_parser::Params::new();
     for (k, v) in &req.params {
@@ -758,7 +813,10 @@ fn cypher_logic(db: &Database, req: Cypher) -> AnyResult<Value> {
             .map(|e| e as &dyn dr_strange_parser::Embedder),
         &params,
     )
-    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    .map_err(|e| match &why_no_embedder {
+        Some(cause) => anyhow::anyhow!("{e} — embedding provider '{provider}': {cause}"),
+        None => anyhow::anyhow!("{e}"),
+    })?;
     let plane = db.plane(&req.plane)?;
     match stmt {
         dr_strange_parser::Statement::Read(read) => Ok(scored_rows(
@@ -841,15 +899,21 @@ fn digest_logic(db: &Database, req: Digest, tuning: DigestTuning) -> AnyResult<V
     let embed = !req.no_embed;
     let link = req.link.unwrap_or(true);
 
-    // Provider keys come from the server's environment (never tool params).
-    let chat =
-        dr_strange_llm::build_provider(chat_provider, req.model.as_deref(), None, None, false)?;
+    // Provider keys come from the server's environment (never tool params) —
+    // `key_env` names the variable, it does not carry the key.
+    let chat = dr_strange_llm::build_provider(
+        chat_provider,
+        req.model.as_deref(),
+        None,
+        req.key_env.as_deref(),
+        false,
+    )?;
     let chat_model = chat.model().to_string();
     let embedder = dr_strange_llm::build_provider(
         embed_provider,
         req.embed_model.as_deref(),
         None,
-        None,
+        req.embed_key_env.as_deref(),
         embed,
     )?;
 


### PR DESCRIPTION
## Problem

Two doc comments state the same contract:

`build_provider` — "Build an `OpenAiProvider` from a provider name (a preset
**or a raw base URL**) plus optional overrides"

`preset` — "or `None` for an unknown name — **the caller then treats it as a
raw base URL**"

Only the separate `url` override ever implemented it. A URL passed as the
*name* fell through to

```
unknown provider '<url>'; give a base URL instead
```

— advice most callers had no way to follow, because they have no `url`
parameter to pass. Fourteen call sites are affected:

| | |
|---|---|
| `dr-strange-cli` | `commands.rs:220`, `:418` (query-time embedding), `:562`, `:565` (`ask`) |
| `dr-strange-web` | `cypher_subgraph` (via `make_embedder`), `plane_hybrid`, `plane_ask`, `plane_find`, `digest_run` ×2 |
| `dr-strange-mcp` | `hybrid`, `ask`, `cypher`, `digest` — over stdio and `/mcp` alike |

`drsg digest` was the only surface that worked, because the CLI exposes
`--chat-url` / `--embed-url`.

It is worse than a missing feature on the MCP surface, because those doc
comments are rendered into the tool schema that ships to clients:

```rust
/// Chat provider (preset or base URL); key from the server env.
/// Embedding provider preset or base URL (defaults to the chat provider).
/// Embedding provider for a text `SEARCH … NEAR "…"` (preset or base URL);
```

An agent reads that, passes a base URL, and gets told to pass a base URL.

`cypher` was the worst of the set: it builds the embedder with `.ok()`, so the
real cause was dropped and the query failed as

```
SEARCH by text needs an embedding provider (set the API key)
```

— sending you after a key when the provider spec was the problem.

## Fix

**1. `fix(llm)`** — resolving the base falls back to the name itself when the
name carries a scheme. Carrying a scheme is the whole test: preset names are
bare words and any other bare word was already an error, so nothing that used
to resolve can be reclassified. A mistyped preset still fails as "unknown
provider", pinned by a test.

A raw URL brings no preset, hence no default key env and no default model —
now stated on `build_provider`, with the existing empty-embedding-model guard
pinned by a test.

**2. `feat(mcp)`** — accepting a URL is only half a capability without a way
to name what the preset would have supplied:

- `key_env` / `embed_key_env` on `hybrid`, `ask`, `cypher` and `digest`,
  threaded into the `key_env` argument `build_provider` has always taken and
  these sites always passed `None` for. The parameter is the variable's
  *name*; the key still never travels in params.
- `embed_model` on `cypher`, which had no way to say one.
- `cypher` keeps the provider-construction error and appends it, instead of
  dropping it. The build stays tolerant — a plain `MATCH` must not require a
  provider — but a query that does need one now says why.

All fields optional; presets behave exactly as before.

## Scope

The same `key_env` / model gap remains on the `/rpc` methods and the CLI. I
stopped at the MCP tools rather than unify parameter naming across four crates
in one PR — happy to follow up in whatever shape you prefer.

Supersedes #8: with the contract honoured in `build_provider`, `digest.run`
accepts a base URL with no wrapper at all, so that PR's
`build_provider_flexible` is unnecessary. Only its `key_env` /
`embed_key_env` params remain worth having, which is the follow-up above. #8
is closed.

## Test plan

Four new unit tests in `dr-strange-llm`: a URL name becomes the base URL and
invents no key; presets and an explicit `url` keep precedence; a bare unknown
name still errors; a URL provider still needs an embedding model.

End-to-end against an unreachable endpoint (`http://127.0.0.1:9/v1`), before
and after — every surface moves from "unknown provider" to actually dialling
it:

| | before | after |
|---|---|---|
| `/rpc` `digest.run` | unknown provider | connection refused |
| `/mcp` `digest`, `hybrid` | unknown provider | connection refused |
| stdio `digest`, `hybrid` | unknown provider | connection refused |
| stdio `cypher` + `embed_model` | "set the API key" | connection refused |
| stdio `cypher`, no model | "set the API key" | …**+ `has no embedding model`** |
| stdio `cypher`, plain `MATCH`, no provider | works | works |

- `cargo test --workspace` — 617 passed, 0 failed
- `RUSTFLAGS=-D warnings cargo clippy --workspace --all-targets` — clean
- `cargo fmt --all --check` — clean

Merges cleanly with #5, #6 and #7.
