### PR TITLE
perf(plugins): compile wasm components in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,6 +4377,7 @@ dependencies = [
  "once_cell",
  "postcard",
  "pulley-interpreter",
+ "rayon",
  "rustix",
  "semver",
  "serde",

--- a/crates/dr-strange-llm/Cargo.toml
+++ b/crates/dr-strange-llm/Cargo.toml
@@ -55,10 +55,15 @@ tracing.workspace = true
 # Trimmed hard: the default feature set carries async, three GC strategies,
 # threads, stack-switching, profiling, coredump, caching and `wat`, none of
 # which a synchronous one-call-per-input host uses.
+# `parallel-compilation` is the one addition back: compiling the installed
+# components dominates `Plugins::load` — measured 13.7s for six, and single-
+# threaded to the millisecond (13.5s user of 13.8s wall) — and every load pays
+# it again. It only pulls in rayon, which this crate already depends on.
 wasmtime = { version = "47", default-features = false, features = [
     "runtime",
     "component-model",
     "cranelift",
+    "parallel-compilation",
     "std",
 ], optional = true }
 wasmtime-wasi = { version = "47", optional = true }


### PR DESCRIPTION
`Plugins::load` compiles every installed component, and that compilation is the
whole cost of loading them. The measurement that makes it unambiguous:

| what is digested | wall | user |
|---|---|---|
| a two-line `.rs` | 13.777s | 13.508s |
| a file no plugin claims | 13.755s | — |

The two are identical, because nothing is being parsed in either case. And
`user ≈ wall` is the tell: the compilation was running on one thread.

This is not a one-off startup cost. `serve watch` reloads the registry inside
the fold — deliberately, so that a `plugin install` between two commits is
picked up — so every folded commit pays it again.

wasmtime's `parallel-compilation` feature only pulls in rayon, which
`dr-strange-llm` already depends on, so the lockfile gains a single line.

Measured on the same file: **13.777s → 2.165s**. Total CPU is unchanged; it is
spread across cores. Digest output is byte-identical, and on a watched
repository the plane is servable 3.9s after start instead of ~15s.
