### PR TITLE
fix(plugins): let one unparseable file cost one file, not the tree

### DIFF
--- a/crates/dr-strange-core/src/compact.rs
+++ b/crates/dr-strange-core/src/compact.rs
@@ -111,6 +111,13 @@ fn candidates(name: &str, hits: &[NodeRecord]) -> String {
 /// clears when it finishes. Written by the digest side; read here.
 pub const REBUILDING_PROP: &str = "rebuilding_since";
 
+/// How long a marker sits before the rebuild that set it is presumed dead.
+///
+/// Ten minutes is far past an honest fold — a forty-thousand-node plane
+/// rebuilds in seconds — so the only thing this reclassifies is a rebuild that
+/// is not coming back.
+const REBUILD_PRESUMED_DEAD: i64 = 600;
+
 /// A rebuild in flight, stated wherever an answer is read.
 ///
 /// A full resync drops the plane and refills it, so in between a query meets a
@@ -130,6 +137,19 @@ fn rebuilding_note(props: &Properties) -> Option<String> {
         .map(|d| d.as_secs() as i64 - since)
         .unwrap_or(0)
         .max(0);
+    // Past a point, "ask again when it finishes" is advice for something that
+    // is not going to happen: a rebuild that failed or was killed leaves the
+    // marker behind — deliberately, see above — and only its age distinguishes
+    // that from one still running. Saying which costs one comparison and is
+    // the difference between a plane a caller waits on and one a caller fixes.
+    if ago >= REBUILD_PRESUMED_DEAD {
+        return Some(format!(
+            "note: this plane was left mid-rebuild {ago}s ago and nothing has \
+             finished it — it holds only what had been folded by then, so a miss \
+             here may mean \"never folded\" rather than \"not present\". Re-run \
+             the rebuild (`serve watch --force`) to replace it.\n"
+        ));
+    }
     Some(format!(
         "note: this plane is being rebuilt (started {ago}s ago) — it holds only \
          what has been folded so far, so a miss here may mean \"not yet\" \
@@ -690,6 +710,31 @@ mod tests {
         assert!(
             !out.contains("synced: commit"),
             "a rebuilding plane must not also claim to be synced: {out}"
+        );
+    }
+
+    /// A marker outlives the process that set it — on purpose, because a plane
+    /// left half-folded is exactly what a caller needs warning about. But past
+    /// a point "ask again when it finishes" is advice about something that is
+    /// never going to finish, and the note has to say so instead.
+    #[test]
+    fn an_abandoned_rebuild_stops_telling_callers_to_wait() {
+        let db = seeded();
+
+        mark_rebuilding(&db, now() - REBUILD_PRESUMED_DEAD + 5);
+        let waiting = context(&db.plane("code").unwrap(), "m::nope").unwrap();
+        assert!(waiting.contains("being rebuilt"), "{waiting}");
+
+        mark_rebuilding(&db, now() - REBUILD_PRESUMED_DEAD - 5);
+        let stalled = context(&db.plane("code").unwrap(), "m::nope").unwrap();
+        assert!(stalled.contains("no symbol matches"), "{stalled}");
+        assert!(
+            stalled.contains("left mid-rebuild") && stalled.contains("--force"),
+            "an abandoned rebuild should name the fix, not ask for patience: {stalled}"
+        );
+        assert!(
+            !stalled.contains("ask again when it finishes"),
+            "nothing is going to finish it: {stalled}"
         );
     }
 

--- a/crates/dr-strange-llm/src/preprocess/mod.rs
+++ b/crates/dr-strange-llm/src/preprocess/mod.rs
@@ -613,9 +613,28 @@ pub fn route_paths(
         match idx {
             Some(i) => {
                 let mark = registry[i].manifest().stamp();
-                let mut out = registry[i].preprocess(&Input::Files { paths: &paths }, host)?;
-                stamp_provenance(&mut out, &mark);
-                merge(&mut merged, out, &mark, &mut owners);
+                match registry[i].preprocess(&Input::Files { paths: &paths }, host) {
+                    Ok(mut out) => {
+                        stamp_provenance(&mut out, &mark);
+                        merge(&mut merged, out, &mark, &mut owners);
+                    }
+                    // A handler that fails outright loses its own files, not
+                    // the tree — the same rule `read_unclaimed` applies one arm
+                    // below, and for the same reason. Before this, one file a
+                    // plugin choked on took every other language in the
+                    // repository with it, and the ingest reported nothing at
+                    // all rather than reporting what it had.
+                    Err(why) => {
+                        let why = format!("{why:#}");
+                        tracing::warn!(handler = %mark, files = paths.len(), error = %why, "handler failed");
+                        merged.report.skipped += paths.len();
+                        merged.report.notes.push(format!(
+                            "`{mark}` failed and its {} file(s) were skipped: {}",
+                            paths.len(),
+                            first_line(&why)
+                        ));
+                    }
+                }
             }
             None => read_unclaimed(host, &paths, &mut merged, &mut owners),
         }
@@ -623,6 +642,15 @@ pub fn route_paths(
 
     merged.report.prose_chars = merged.prose.chars().count();
     Ok(merged)
+}
+
+/// The first line of an error, for a note that has to stay one line.
+///
+/// A trap arrives with a wasm backtrace and possibly a page of guest stderr
+/// attached; the sentence in front of it is the part a report can carry, and
+/// the log has already taken the whole thing.
+pub(crate) fn first_line(why: &str) -> &str {
+    why.lines().next().unwrap_or(why).trim_end()
 }
 
 /// Hand every unclaimed file to the built-in reader.

--- a/crates/dr-strange-llm/src/preprocess/tests.rs
+++ b/crates/dr-strange-llm/src/preprocess/tests.rs
@@ -855,3 +855,75 @@ fn folds_converge_with_full_rebuild() {
         "a fold-built plane must equal the digest-built plane"
     );
 }
+
+/// A handler that refuses whatever it is given, the way a plugin does when its
+/// guest traps. The message is shaped like a real one: a diagnosis, then the
+/// evidence under it.
+struct Trapping;
+
+impl Preprocessor for Trapping {
+    fn manifest(&self) -> Manifest {
+        Manifest {
+            name: "trapping".into(),
+            version: "1".into(),
+            extensions: vec!["go".into()],
+            logo: None,
+        }
+    }
+
+    fn preprocess(&self, _input: &Input<'_>, _host: &dyn Host) -> Result<Preprocessed> {
+        Err(anyhow::anyhow!(
+            "plugin `trapping` trapped: wasm trap: out of bounds memory access\n\
+             error while executing at wasm backtrace:\n    0:  0x4cd01 - expr1"
+        ))
+    }
+}
+
+/// One handler failing costs its own files, not the tree.
+///
+/// This is the rule `read_unclaimed` has always applied to the PNG it cannot
+/// read, and the rule the plugin arm did not: a single generated file that
+/// tripped a plugin used to abort the whole ingest, so a repository lost every
+/// other language in it — and reported nothing rather than reporting what it
+/// had.
+#[test]
+fn a_failing_handler_does_not_take_the_tree_with_it() {
+    let t = Tree::new("failing-handler");
+    t.write("a.go", "package main");
+    t.write("b.go", "package main");
+    t.write("src/lib.rs", "pub fn a() {}");
+    t.write("notes.md", "# Hi");
+    let host = t.host();
+    let plugins = Plugins::from_handlers(vec![Box::new(Probe), Box::new(Trapping)]);
+
+    let out = route_tree(&host, None, &plugins).unwrap();
+
+    // Everything the failing handler did not claim came through untouched.
+    assert_eq!(
+        out.nodes.len(),
+        1,
+        "the .rs file still parsed: {:?}",
+        out.nodes
+    );
+    assert!(out.prose.contains("Hi"), "the .md file still read");
+
+    // Its own files are counted, not silently dropped.
+    assert_eq!(out.report.skipped, 2, "both .go files: {:?}", out.report);
+
+    // And the note names the handler and the reason — on one line, because a
+    // wasm backtrace does not belong in a report.
+    let note = out
+        .report
+        .notes
+        .iter()
+        .find(|n| n.contains("trapping@1"))
+        .unwrap_or_else(|| panic!("no note named the handler: {:?}", out.report.notes));
+    assert!(
+        note.contains("out of bounds memory access"),
+        "the note should carry the reason: {note}"
+    );
+    assert!(
+        !note.contains("0x4cd01"),
+        "the backtrace belongs in the log, not the report: {note}"
+    );
+}

--- a/crates/dr-strange-llm/src/preprocess/wasm.rs
+++ b/crates/dr-strange-llm/src/preprocess/wasm.rs
@@ -108,6 +108,17 @@ const DEFAULT_FUEL: u64 = 200_000_000_000;
 /// whatever this is set to.
 const DEFAULT_MEMORY: usize = 3 << 30;
 
+/// A memory fault this close to the top of a 32-bit address space is not a
+/// wild pointer: it is a stack pointer that walked below zero and wrapped.
+///
+/// It is worth naming, because a guest's stack is *not* the one
+/// `Config::max_wasm_stack` governs — that one holds the compiled wasm frames.
+/// A guest's own stack lives at the bottom of its linear memory, and its size
+/// is fixed when the plugin is built (`tinygo -stack-size`, `wasm-ld
+/// -z stack-size`). So no host setting raises it, and the trap message
+/// otherwise reads like a corrupt module rather than a deep input.
+const SP_UNDERFLOW: &str = "memory fault at wasm address 0xffff";
+
 impl Default for Limits {
     fn default() -> Self {
         Self {
@@ -348,15 +359,17 @@ impl WasmPlugin {
                  or the input is larger than `[plugins] fuel` allows for"
             );
         }
+        let why = trap_message(name, &format!("{error}"), &format!("{error:#}"));
+
         let said = store.data().stderr.contents();
         if said.is_empty() {
-            return anyhow!("plugin `{name}` trapped: {error}");
+            return anyhow!("{why}");
         }
         // The tail, because a panic message comes last and the front of a
         // long log is the least interesting part of it.
         let tail = said.len().saturating_sub(2048);
         let said = String::from_utf8_lossy(&said[tail..]).trim().to_string();
-        anyhow!("plugin `{name}` trapped: {error}\nits stderr said:\n{said}")
+        anyhow!("{why}\nits stderr said:\n{said}")
     }
 }
 
@@ -367,6 +380,8 @@ impl Preprocessor for WasmPlugin {
 
     fn preprocess(&self, input: &Input<'_>, host: &dyn Host) -> Result<Preprocessed> {
         let started = std::time::Instant::now();
+        // What this plugin could not parse: `(the chunk, why)`.
+        let mut refused: Vec<(String, String)> = Vec::new();
         // Phase one: chunks in parallel, partials collected in chunk order —
         // par_iter's collect preserves order, which is the same discipline the
         // native parser used for exactly the same reason.
@@ -380,12 +395,56 @@ impl Preprocessor for WasmPlugin {
                     host,
                 )?]
             }
-            Input::Files { paths } => paths
-                .chunks(CHUNK_FILES)
-                .collect::<Vec<_>>()
-                .par_iter()
-                .map(|chunk| self.parse_chunk(wit_plugin::Input::Files(chunk.to_vec()), host))
-                .collect::<Result<Vec<_>>>()?,
+            Input::Files { paths } => {
+                let chunks: Vec<&[String]> = paths.chunks(CHUNK_FILES).collect();
+                let parsed: Vec<Result<Vec<u8>>> = chunks
+                    .par_iter()
+                    .map(|chunk| self.parse_chunk(wit_plugin::Input::Files(chunk.to_vec()), host))
+                    .collect();
+                let mut kept = Vec::with_capacity(parsed.len());
+                for (chunk, result) in chunks.iter().zip(parsed) {
+                    match result {
+                        Ok(partial) => kept.push(partial),
+                        // A file this plugin chokes on is counted, not fatal —
+                        // the same rule the built-in reader applies to the PNG
+                        // it cannot read. One generated file used to take the
+                        // whole tree down with it, and the tree is the point.
+                        // Which file, too: a chunk is one call, so the error
+                        // can name its input instead of leaving a reader to
+                        // bisect a few thousand paths for it.
+                        Err(why) => {
+                            let files = chunk.join(", ");
+                            let why = format!("{why:#}");
+                            tracing::warn!(
+                                plugin = %self.manifest.name,
+                                files = %files,
+                                error = %why,
+                                "file skipped: the plugin could not parse it"
+                            );
+                            refused.push((files, why));
+                        }
+                    }
+                }
+                // Containment has a floor, and the floor is evidence: a plugin
+                // that parsed *something* has demonstrated it works, so what
+                // failed is about those files. One that parsed nothing at all
+                // has demonstrated nothing — it is broken, out of fuel, or
+                // reaching for what the sandbox refuses — and that is worth an
+                // error rather than an empty plane and a note. The sandbox's
+                // own refusals arrive exactly this way, one file at a time,
+                // and must keep arriving as errors. No ratio in between: any
+                // threshold there would be a number nobody could defend.
+                if kept.is_empty() && !refused.is_empty() {
+                    let (first, why) = &refused[0];
+                    bail!(
+                        "plugin `{}` parsed none of its {} input(s) — that is the \
+                         plugin, not the tree. The first was {first}: {why}",
+                        self.manifest.name,
+                        chunks.len()
+                    );
+                }
+                kept
+            }
         };
         let parsed = std::time::Instant::now();
 
@@ -401,7 +460,14 @@ impl Preprocessor for WasmPlugin {
             assemble_ms = parsed.elapsed().as_millis() as u64,
             "preprocess phases"
         );
-        into_preprocessed(out, &self.manifest.name)
+        let mut out = into_preprocessed(out, &self.manifest.name)?;
+        if !refused.is_empty() {
+            out.report.skipped += refused.len();
+            out.report
+                .notes
+                .push(refusal_note(&self.manifest.name, &refused));
+        }
+        Ok(out)
     }
 }
 
@@ -494,6 +560,63 @@ fn refuse_forbidden_imports(engine: &Engine, component: &Component) -> Result<()
 }
 
 /// Cross back: WIT records into the shapes the digest pipeline already writes.
+/// A trap, worded so that its first line is the diagnosis.
+///
+/// What wasmtime *displays* is the wasm backtrace; the reason — "wasm trap:
+/// out of bounds memory access" — hangs off the source chain behind it, and
+/// only the alternate form renders that. So a trap used to arrive as twenty
+/// frames (wasmtime's own default cap) that never said what had gone wrong,
+/// and a one-line summary of it said nothing at all. The difference between
+/// the two renderings is exactly the cause chain, which is how the reason is
+/// lifted out and put first, with the evidence underneath it — the repeated
+/// frame in a backtrace is what names a recursion.
+fn trap_message(plugin: &str, backtrace: &str, full: &str) -> String {
+    let reason = full
+        .strip_prefix(backtrace)
+        .map(|tail| tail.trim_start_matches(':').trim())
+        .filter(|tail| !tail.is_empty())
+        .unwrap_or(full);
+
+    let mut why = format!("plugin `{plugin}` trapped: {reason}");
+    // A stack pointer that walked below zero is worth naming, because "out of
+    // bounds memory access" otherwise reads as a corrupt module.
+    if reason.contains(SP_UNDERFLOW) {
+        why.push_str(
+            "\nthat address is the plugin's own stack underflowing, not a wild \
+             pointer: the input nests deeper than the stack the plugin was built \
+             with. A generated file is the usual cause — a descriptor written as \
+             one long chain of `+` is a single expression hundreds of levels deep, \
+             however short its lines look. Only a rebuilt plugin raises that \
+             ceiling; excluding the file is the local fix.",
+        );
+    }
+    if reason != full {
+        why.push('\n');
+        why.push_str(backtrace);
+    }
+    why
+}
+
+/// The files a plugin refused, as one note.
+///
+/// Capped, because a tree that trips a plugin on four hundred files has one
+/// bug and not four hundred, and the first few name it. The count is exact
+/// either way — that is what `skipped` is for.
+fn refusal_note(plugin: &str, refused: &[(String, String)]) -> String {
+    const NAMED: usize = 5;
+    let mut note = format!(
+        "plugin `{plugin}` could not parse {} file(s), which were skipped:",
+        refused.len()
+    );
+    for (files, why) in refused.iter().take(NAMED) {
+        note.push_str(&format!("\n  {files}: {}", super::first_line(why)));
+    }
+    if refused.len() > NAMED {
+        note.push_str(&format!("\n  … and {} more", refused.len() - NAMED));
+    }
+    note
+}
+
 fn into_preprocessed(out: wit_plugin::Output, plugin: &str) -> Result<Preprocessed> {
     let nodes = out
         .nodes
@@ -548,4 +671,52 @@ fn properties(json: &str, plugin: &str) -> Result<dr_strange_core::Properties> {
     })?;
     dr_strange_core::json::json_to_properties(&value)
         .map_err(|e| anyhow!("plugin `{plugin}` returned properties we cannot read: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim from a go plugin trapping on a 92-term string concatenation,
+    /// trimmed to three frames. `backtrace` is what `{}` rendered; `full` is
+    /// what `{:#}` rendered — the same text, plus the cause chain.
+    const BACKTRACE: &str = "error while executing at wasm backtrace:\n    \
+                             0:  0x4cb94 - main!(*go/printer.printer).expr1\n    \
+                             1:  0x4cd01 - main!(*go/printer.printer).expr1\n    \
+                             2:  0x4cd01 - main!(*go/printer.printer).expr1";
+    const CAUSES: &str = ": memory fault at wasm address 0xfffffe50 in linear memory \
+                          of size 0x40000: wasm trap: out of bounds memory access";
+
+    #[test]
+    fn a_trap_leads_with_the_reason_not_the_backtrace() {
+        let full = format!("{BACKTRACE}{CAUSES}");
+        let msg = trap_message("go", BACKTRACE, &full);
+
+        // The first line is the diagnosis, which is all a one-line report note
+        // carries — it used to be "error while executing at wasm backtrace:".
+        let first = super::super::first_line(&msg);
+        assert!(
+            first.starts_with("plugin `go` trapped: memory fault at wasm address"),
+            "the reason should lead: {first}"
+        );
+        assert!(
+            first.ends_with("out of bounds memory access"),
+            "the root cause should survive: {first}"
+        );
+        // The evidence is kept, under the diagnosis.
+        assert!(msg.contains("expr1"), "the backtrace should still be there");
+        // And a fault in the top of the address space is named for what it is.
+        assert!(
+            msg.contains("stack underflowing"),
+            "a wrapped stack pointer should be explained: {msg}"
+        );
+    }
+
+    #[test]
+    fn a_trap_with_no_cause_chain_is_left_alone() {
+        // Nothing hangs off it: both renderings agree, so there is nothing to
+        // lift out and no reason to print the same text twice.
+        let msg = trap_message("go", BACKTRACE, BACKTRACE);
+        assert_eq!(msg, format!("plugin `go` trapped: {BACKTRACE}"));
+    }
 }


### PR DESCRIPTION
One generated Go file aborted the indexing of a 2491-file repository. Reported from a real tree (drsg v2.0.1 + go-v1.3.0): `protoc-gen-go` v1.36 writes `rawDesc` as a 96-part string concatenation, the plugin's printer recurses once per term, the guest runs out of stack — and `route_paths` then returned `Err`, so the ingest produced **nothing at all**, for every language in the tree, rather than producing what it had. The only way to learn which file it was, was to bisect a few thousand paths.

### What changes

**A failing file costs a file.** `CHUNK_FILES` is 1, so a `parse` call is one file: the failure is counted, noted **with the file's name**, and the rest of the tree goes on. This is the rule `read_unclaimed` (`preprocess/mod.rs`) has always applied to the PNG it cannot read — the plugin arm simply never got it.

Containment has a floor, and the floor is evidence: a plugin that parsed *something* has demonstrated it works, so what failed is about those files; one that parsed **nothing** has demonstrated nothing and still errors. That is what keeps the sandbox's own refusals — fuel exhaustion, the memory bomb, an attempted escape — arriving as errors, and `tests/sandbox.rs` passes unchanged. There is deliberately no ratio in between; any threshold there would be a number nobody could defend.

**A failing handler costs its own files**, not the tree — matching the arm directly below it in the same `match`.

**A trap says what happened.** It used to read:

```
plugin `go` trapped: error while executing at wasm backtrace:
    0:  0x33c26 - main!(*go/token.File).position
    ... 18 more frames ...
```

and stop there. wasmtime's `Display` **is** the backtrace; the reason hangs off its source chain, which only `{:#}` renders, and wasmtime's own default caps the frames at 20. The difference between the two renderings is exactly the cause chain, so it is lifted out and put first, with the evidence beneath it:

```
plugin `go` trapped: memory fault at wasm address 0xfffffe50 in linear memory of size 0x40000: wasm trap: out of bounds memory access
that address is the plugin's own stack underflowing, not a wild pointer: the input nests
deeper than the stack the plugin was built with. […] Only a rebuilt plugin raises that
ceiling; excluding the file is the local fix.
error while executing at wasm backtrace:
    …
```

That first line is what a one-line report note can carry, which is the whole reason for the reshuffle.

**An abandoned rebuild stops asking for patience.** `rebuilding_since` outliving the process that set it is deliberate and stays that way — a half-folded plane is exactly what a caller needs warning about. But past ten minutes, "ask again when it finishes" is advice about something that is never going to finish, so the note says the plane was left mid-rebuild and names the fix.

### The diagnosis this corrects

The report that prompted this concluded the wasmtime call stack was exhausted and asked for `Config::max_wasm_stack`. Measured against the go plugin with a synthetic file of N concatenated terms, **91 parses and 92 traps** — and that threshold is *identical* at wasmtime's 512 KiB default and at 8 MiB. The stack that overflows is the guest's own, at the bottom of its linear memory (0x40000 total; the fault address 0xfffffe50 is a stack pointer that walked below zero and wrapped), and its size is fixed when the plugin is built. No host setting raises it. So `max_wasm_stack` is not in this PR; what is in it is the message that says so, and the containment that makes one such file survivable.

Worth noting separately for the extensions repo: the go plugin would benefit from a larger `-stack-size` at build time.

### Tests

- `preprocess::wasm::tests` — two new: the reason leads the message and the backtrace survives under it; a trap with no cause chain is left alone. The fixture strings are verbatim from the real trap.
- `preprocess::tests::a_failing_handler_does_not_take_the_tree_with_it` — the `.rs` and `.md` files still come through, both `.go` files are counted, and the note carries the reason but not the backtrace.
- `compact::tests::an_abandoned_rebuild_stops_telling_callers_to_wait`.
- `tests/sandbox.rs` — unchanged, and passing, which is the assertion that the floor holds.

`cargo test --workspace --release`, `cargo test -p dr-strange-core --features json`, the redb smoke (`--no-default-features --features redb-backend,json`), `cargo clippy --workspace --all-targets` under `-D warnings`, and `cargo fmt --all --check`: all clean.
