### PR TITLE
fix(errors): say what to write, not where the parse stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Dr Strange are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A `RETURN` this subset does not have now says so.** Appendix B promises
+  projections and aggregation are "a clear error, never a silent
+  mis-compile", but `RETURN f.file, f.line, key(f)` stopped the parse at the
+  first dot and surfaced as `unexpected trailing input near \`.file, …\`` — a
+  position, not an answer, and it reads like a typo in a query that has none.
+  Each shape now names itself and says what to write instead: a projection, a
+  column list, a call in RETURN, an `AS` alias. Written for the callers who
+  actually hit it — agents on the MCP `cypher` tool, for whom the error
+  message is the only documentation in reach. The tool's own description now
+  states the restriction too, so the query arrives right the first time.
+- **The MCP `search` tool pointed at a config section that does not exist.**
+  Without an embedding provider it said to set "`[server]` embed provider",
+  but the keys live under `[digest]` — and `[server]` denies unknown fields,
+  so an operator who followed the hint got a server that would not start. It
+  now names `[digest] embed_provider` and `embed_key_env`, and points at
+  `grep` for the text search that needs no provider at all.
+
 ## [2.1.1] - 2026-08-25
 
 ### Changed

--- a/crates/dr-strange-mcp/src/lib.rs
+++ b/crates/dr-strange-mcp/src/lib.rs
@@ -1540,9 +1540,16 @@ impl DrStrange {
         let embed = self.embed.clone();
         self.blocking("search", move |db| {
             let Some(cfg) = &embed else {
+                // The section is `[digest]`, and saying `[server]` was worse
+                // than saying nothing: `[server]` denies unknown fields, so an
+                // operator who followed this hint got a server that would not
+                // start.
                 anyhow::bail!(
                     "no embed provider configured on this server — set \
-                     [server] embed provider (and its key env) in drsg.toml"
+                     `[digest] embed_provider` in drsg.toml (with \
+                     `embed_key_env` naming the environment variable that \
+                     holds the key), then restart; `grep` searches the tree by \
+                     text without one"
                 );
             };
             let embedder = dr_strange_llm::build_provider(
@@ -1728,7 +1735,10 @@ impl DrStrange {
         CALL pagerank|components|shortest_path|louvain(args) ON (v[:L]) — graph \
         algorithms. Then BEAM similarity traversal, WHERE (property/label \
         tests, key(n) for a node's external key, x IN [a,b]), \
-        RETURN [DISTINCT], ORDER BY/SKIP/LIMIT, and a trailing \
+        RETURN [DISTINCT] <var>|* — one variable, the pattern's last, and \
+        whole records come back, so there is no column list, projection \
+        (`RETURN f.file`), alias or aggregate; ORDER BY/SKIP/LIMIT take \
+        expressions (`ORDER BY f.line`), and a trailing \
         AS OF <seq|\"RFC-3339\"|TIME ms> to read a past snapshot. \
         Writes (CREATE/MERGE/SET/REMOVE/DELETE) mutate the plane and return \
         change-counts. Examples: \

--- a/crates/dr-strange-parser/src/lib.rs
+++ b/crates/dr-strange-parser/src/lib.rs
@@ -210,12 +210,15 @@ fn parse_statement_inner(
 ) -> Result<Statement, ParseError> {
     let (rest, stmt) = parse::statement(input).map_err(|e| ParseError::Syntax(describe(e)))?;
     // Everything must be consumed — trailing tokens mean a mistyped clause.
-    let rest = rest.trim();
-    if !rest.is_empty() {
-        return Err(ParseError::Syntax(format!(
-            "unexpected trailing input near `{}`",
-            snippet(rest)
-        )));
+    let rest = rest.trim_start();
+    if !rest.trim_end().is_empty() {
+        return Err(match unsupported_return(input, rest) {
+            Some(why) => ParseError::Compile(why),
+            None => ParseError::Syntax(format!(
+                "unexpected trailing input near `{}`",
+                snippet(rest.trim_end())
+            )),
+        });
     }
     Ok(match stmt {
         ast::StmtAst::Read(query) => {
@@ -227,6 +230,78 @@ fn parse_statement_inner(
             Statement::Write(write::compile(w, params.clone()).map_err(ParseError::Compile)?)
         }
     })
+}
+
+/// Read a RETURN this subset does not have, and say so in those terms.
+///
+/// `RETURN` takes one variable or `*` (appendix B), so full Cypher's
+/// projections stop the parse mid-clause and surface as "unexpected trailing
+/// input near `.file, …`" — a position, not an answer, and appendix B promises
+/// these are "a clear error, never a silent mis-compile". Whoever wrote
+/// `RETURN f.file, f.line` needs to hear that whole records come back anyway,
+/// not to go hunting for a typo that isn't there.
+///
+/// `rest` is what the parse left, so it is a suffix of `input`: the text
+/// before it is what parsed, and the RETURN clause is recognised there rather
+/// than guessed at, which keeps a `WHERE n.name = 'return'` from being read as
+/// one.
+fn unsupported_return(input: &str, rest: &str) -> Option<String> {
+    let var = returned_variable(&input[..input.len() - rest.len()])?;
+    let what = match rest.as_bytes().first()? {
+        b'.' => format!(
+            "RETURN takes one variable or `*`, so the projection `{var}.…` is not \
+             supported — `RETURN {var}` hands back whole records, properties and \
+             all, and ORDER BY still takes `{var}.…`"
+        ),
+        b',' => format!(
+            "RETURN takes one variable or `*`, so a column list is not supported — \
+             `RETURN {var}` hands back whole records, properties and all"
+        ),
+        b'(' => format!(
+            "RETURN takes one variable or `*`, so calling `{var}(…)` in it is not \
+             supported — there is no aggregation, and `key()` and `score()` belong \
+             in WHERE and ORDER BY; a returned record already carries the key"
+        ),
+        _ => {
+            let after_as = keyword_tail(rest, "as")?;
+            // `AS OF …` is a real clause and parses; reaching here with `OF`
+            // next means its argument is the problem, not an alias.
+            if keyword_tail(after_as, "of").is_some() {
+                return None;
+            }
+            format!(
+                "RETURN takes one variable or `*`, so aliasing `{var}` with AS is not supported"
+            )
+        }
+    };
+    Some(format!("{what} (near `{}`)", snippet(rest.trim_end())))
+}
+
+/// The variable a RETURN clause got as far as naming, if `parsed` ends in one:
+/// the last `RETURN` keyword, an optional `DISTINCT`, and a bare identifier —
+/// exactly what the grammar accepts, and nothing else in between.
+fn returned_variable(parsed: &str) -> Option<&str> {
+    let at = parsed.to_ascii_lowercase().rfind("return")?;
+    let after = keyword_tail(&parsed[at..], "return")?;
+    let after = keyword_tail(after, "distinct").unwrap_or(after).trim();
+    let ident = !after.is_empty()
+        && after.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !after.starts_with(|c: char| c.is_ascii_digit());
+    ident.then_some(after)
+}
+
+/// What follows `word` in `s`, when `s` opens with that keyword as a whole
+/// word — `None` when it does not, so `ordered` never reads as `order`.
+fn keyword_tail<'a>(s: &'a str, word: &str) -> Option<&'a str> {
+    let s = s.trim_start();
+    let (head, tail) = s.split_at_checked(word.len())?;
+    if !head.eq_ignore_ascii_case(word) {
+        return None;
+    }
+    match tail.chars().next() {
+        Some(c) if c.is_ascii_alphanumeric() || c == '_' => None,
+        _ => Some(tail),
+    }
 }
 
 fn describe(e: nom::Err<nom::error::Error<&str>>) -> String {

--- a/crates/dr-strange-parser/tests/parse.rs
+++ b/crates/dr-strange-parser/tests/parse.rs
@@ -295,6 +295,57 @@ fn rejects_trailing_and_missing_clauses() {
     assert!(matches!(err("RETURN n"), ParseError::Syntax(_)));
 }
 
+/// Appendix B promises projections and aggregation are "a clear error, never
+/// a silent mis-compile". A position in the middle of the clause is not that
+/// error: `RETURN f.file, f.line, key(f)` stops the parse at the first dot and
+/// used to surface as "unexpected trailing input near `.file, …`", which reads
+/// like a typo in a query that has none. Each shape now names itself, and says
+/// what this subset takes instead — these queries arrive from agents, and the
+/// message is the only documentation they get.
+#[test]
+fn an_unsupported_return_says_which_shape_and_what_to_write() {
+    let cases = [
+        ("MATCH (f:Fn) RETURN f.file, f.line, key(f)", "projection"),
+        ("MATCH (f:Fn) RETURN f, key(f)", "column list"),
+        ("MATCH (f:Fn) RETURN key(f)", "key(…)"),
+        ("MATCH (f:Fn) RETURN count(f)", "count(…)"),
+        ("MATCH (f:Fn) RETURN f AS name", "aliasing"),
+    ];
+    for (query, shape) in cases {
+        let e = err(query);
+        assert!(
+            matches!(e, ParseError::Compile(_)),
+            "`{query}` is unsupported, not mistyped: {e}"
+        );
+        let said = e.to_string();
+        assert!(
+            said.contains(shape) && said.contains("RETURN takes one variable or `*`"),
+            "`{query}` should name the shape and the rule: {said}"
+        );
+    }
+    // The position survives, because a long query needs one.
+    assert!(
+        err("MATCH (f:Fn) RETURN f.file")
+            .to_string()
+            .contains(".file")
+    );
+}
+
+/// Trailing text that is *not* a RETURN this subset lacks stays a plain syntax
+/// error — including `AS OF` with an argument it cannot read, which is a
+/// broken clause rather than an alias.
+#[test]
+fn other_trailing_input_is_still_a_syntax_error() {
+    assert!(matches!(
+        err("MATCH (n) RETURN n AS OF yesterday"),
+        ParseError::Syntax(_)
+    ));
+    assert!(matches!(
+        err("MATCH (n) RETURN n LIMIT 5 EXTRA"),
+        ParseError::Syntax(_)
+    ));
+}
+
 #[test]
 fn rejects_contradictory_relationship_direction() {
     // `<-...->` has two arrowheads and is meaningless.


### PR DESCRIPTION
Two messages from a live session, both leaving the reader worse off than silence would have.

`RETURN f.file, f.line, key(f)` came back as "unexpected trailing input near `.file, f.line, f.signature, key(f) ORDER`". The subset takes one variable or `*`, so the parse ended after `f` and reported the leftovers — a position, not an answer, and it reads like a typo in a query that has none. Appendix B already promises projections and aggregation are "a clear error, never a silent mis-compile"; this is that error. Each shape now names itself — a projection, a column list, a call in RETURN, an `AS` alias — and says that whole records come back anyway, so `RETURN f` is what was wanted. The `cypher` tool's own description states the restriction too, because the query that never gets written wrong needs no error at all.

The `search` tool, with no embedding provider, said to set "`[server]` embed provider". The keys are under `[digest]`, and `[server]` denies unknown fields — so an operator who followed the hint got a server that would not start. It now names `[digest] embed_provider` and `embed_key_env`, and points at `grep` for the text search that needs no provider at all.

These arrive over MCP, where the error message is the whole of the documentation an agent can reach: it either recovers on the next call or loops.