### PR TITLE
fix(mcp): grep says why a regex-shaped pattern found nothing

### DIFF
--- a/crates/dr-strange-llm/tests/common/mod.rs
+++ b/crates/dr-strange-llm/tests/common/mod.rs
@@ -1,0 +1,23 @@
+//! What every sandbox suite needs before it can assert anything: the
+//! committed fixture, and somewhere for a call to read from.
+
+use std::path::Path;
+
+use dr_strange_llm::preprocess::{Limits, LocalFiles, WasmPlugin};
+
+/// The committed fixture, loaded in one of its modes.
+pub fn fixture(mode: &str, limits: Limits) -> WasmPlugin {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fixture.wasm");
+    WasmPlugin::load(&path, vec![("mode".to_string(), mode.to_string())], limits)
+        .expect("the committed fixture must load")
+}
+
+/// A scratch dir with one claimable file, for calls that need a host.
+pub fn scratch(name: &str) -> (std::path::PathBuf, LocalFiles) {
+    let dir = std::env::temp_dir().join(format!("drsg-sandbox-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("a.fix"), "x").unwrap();
+    let host = LocalFiles::new(&dir).unwrap();
+    (dir, host)
+}

--- a/crates/dr-strange-llm/tests/gauge.rs
+++ b/crates/dr-strange-llm/tests/gauge.rs
@@ -1,0 +1,50 @@
+//! The plugin memory gauge, alone in its own binary.
+//!
+//! `plugin_memory_bytes` counts what every plugin in the *process* holds, so
+//! a sibling test that loads a fixture moves the figure between this one's
+//! reads. Cargo gives each integration file its own process, which is the
+//! only isolation a global counter can be given.
+#![cfg(feature = "plugins")]
+
+mod common;
+
+use common::{fixture, scratch};
+use dr_strange_llm::plugin_memory_bytes;
+use dr_strange_llm::preprocess::{Input, Limits, Preprocessor};
+
+/// What the plugins hold is a gauge the process can read: loading a plugin
+/// adds its compiled image, a call adds the guest's memory while it runs and
+/// takes it back when it returns, and dropping the plugin takes the image
+/// back — so the figure a dashboard shows beside the resident set is what is
+/// held *now*, not what was ever allocated.
+#[test]
+fn what_the_plugins_hold_is_a_gauge() {
+    let (dir, host) = scratch("gauge");
+    let before = plugin_memory_bytes();
+    let plugin = fixture("ok", Limits::default());
+    let loaded = plugin_memory_bytes();
+    assert!(
+        loaded > before,
+        "a loaded plugin holds its compiled image: {before} -> {loaded}"
+    );
+    plugin
+        .preprocess(
+            &Input::Files {
+                paths: &["a.fix".to_string()],
+            },
+            &host,
+        )
+        .unwrap();
+    assert_eq!(
+        plugin_memory_bytes(),
+        loaded,
+        "a finished call gives the guest's memory back"
+    );
+    drop(plugin);
+    assert_eq!(
+        plugin_memory_bytes(),
+        before,
+        "a dropped plugin gives its image back"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/dr-strange-llm/tests/sandbox.rs
+++ b/crates/dr-strange-llm/tests/sandbox.rs
@@ -4,27 +4,12 @@
 //! needs no wasm toolchain — it is the *host* under test.
 #![cfg(feature = "plugins")]
 
+mod common;
+
 use std::path::Path;
 
-use dr_strange_llm::preprocess::{
-    Input, Limits, LocalFiles, Plugins, Preprocessor, WasmPlugin, route_tree,
-};
-
-fn fixture(mode: &str, limits: Limits) -> WasmPlugin {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fixture.wasm");
-    WasmPlugin::load(&path, vec![("mode".to_string(), mode.to_string())], limits)
-        .expect("the committed fixture must load")
-}
-
-/// A scratch dir with one claimable file, for calls that need a host.
-fn scratch(name: &str) -> (std::path::PathBuf, LocalFiles) {
-    let dir = std::env::temp_dir().join(format!("drsg-sandbox-{name}-{}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    std::fs::write(dir.join("a.fix"), "x").unwrap();
-    let host = LocalFiles::new(&dir).unwrap();
-    (dir, host)
-}
+use common::{fixture, scratch};
+use dr_strange_llm::preprocess::{Input, Limits, Plugins, Preprocessor, WasmPlugin, route_tree};
 
 /// The well-behaved mode round-trips through parse and assemble — the control
 /// the hostile cases are measured against.
@@ -294,44 +279,6 @@ fn a_plugin_that_fails_on_every_file_is_still_fatal() {
     assert!(
         said.contains("all 2") && said.contains("fixture"),
         "the error should say the plugin failed on everything: {said}"
-    );
-    let _ = std::fs::remove_dir_all(&dir);
-}
-
-/// What the plugins hold is a gauge the process can read: loading a plugin
-/// adds its compiled image, a call adds the guest's memory while it runs and
-/// takes it back when it returns, and dropping the plugin takes the image
-/// back — so the figure a dashboard shows beside the resident set is what is
-/// held *now*, not what was ever allocated.
-#[test]
-fn what_the_plugins_hold_is_a_gauge() {
-    use dr_strange_llm::plugin_memory_bytes;
-    let (dir, host) = scratch("gauge");
-    let before = plugin_memory_bytes();
-    let plugin = fixture("ok", Limits::default());
-    let loaded = plugin_memory_bytes();
-    assert!(
-        loaded > before,
-        "a loaded plugin holds its compiled image: {before} -> {loaded}"
-    );
-    plugin
-        .preprocess(
-            &Input::Files {
-                paths: &["a.fix".to_string()],
-            },
-            &host,
-        )
-        .unwrap();
-    assert_eq!(
-        plugin_memory_bytes(),
-        loaded,
-        "a finished call gives the guest's memory back"
-    );
-    drop(plugin);
-    assert_eq!(
-        plugin_memory_bytes(),
-        before,
-        "a dropped plugin gives its image back"
     );
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/dr-strange-mcp/src/lib.rs
+++ b/crates/dr-strange-mcp/src/lib.rs
@@ -929,6 +929,11 @@ fn grep_tree(
     ];
     const MAX_FILE: u64 = 2 * 1024 * 1024;
     const MAX_LINE: usize = 300;
+    // Constructs that are near-certainly a reach for a pattern language this
+    // search does not have. `(`, `[` and a lone `.` are deliberately absent:
+    // they are ordinary in a literal code search (`TrimPrefix(`), and a hint
+    // that cries wolf is a hint that gets read past.
+    const REGEX_TELLS: &[&str] = &["|", ".*", ".+", r"\d", r"\w", r"\s", r"\b"];
     let cap = req.max_results.unwrap_or(50).clamp(1, 200);
     let around = req.context.unwrap_or(0).min(10);
     let matcher = Matcher::new(req)?;
@@ -1046,6 +1051,19 @@ fn grep_tree(
         out.push_str("no matches\n");
         if let Some(f) = filter {
             out.push_str(&format!("(searched only `{f}`; drop `path` to widen)\n"));
+        }
+        // A regex-shaped pattern sent to a literal search fails exactly like a
+        // real absence: both say "no matches". That silence is what turns a
+        // mis-typed pattern into "I checked, it isn't there" in someone's
+        // conclusion. Only when `regex` was not asked for — having asked, an
+        // empty result means what it says.
+        if !req.regex.unwrap_or(false)
+            && let Some(tell) = REGEX_TELLS.iter().find(|t| req.pattern.contains(**t))
+        {
+            out.push_str(&format!(
+                "note: search text contains a regexp pattern ({tell}). it seems to be a pattern match \
+                 but `regex` flag argument set to false. you can retry this search with `regex` flag set to true.\n"
+            ));
         }
     } else if capped {
         out.push_str(&format!(
@@ -3363,6 +3381,58 @@ mod grep_tests {
         assert_eq!(index.enclosing("src/m.rs", 12), Some("m::f"));
         assert_eq!(index.enclosing("src/m.rs", 30), Some("m::g"));
         assert_eq!(index.enclosing("src/m.rs", 9), None);
+    }
+
+    /// A regex handed to a literal search returns `no matches` — the same words
+    /// a real absence returns. Both observed cases came back silent and were
+    /// written up as "checked, not present"; the note is what breaks the tie.
+    #[test]
+    fn a_regex_shaped_pattern_says_why_it_found_nothing() {
+        let dir = std::env::temp_dir().join(format!("drsg-grep-re-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("a.rs"), "fn alpha() {}\nfn beta() {}\n").unwrap();
+
+        for pattern in ["alpha|beta", r#"TrimPrefix(.*"models/""#] {
+            let out = grep_tree(&dir, &req(pattern), None).unwrap();
+            assert!(out.contains("no matches"), "{pattern}: {out}");
+            assert!(out.contains("regexp pattern"), "{pattern}: {out}");
+            assert!(
+                out.contains("retry this search with `regex` flag set to true"),
+                "{pattern}: {out}"
+            );
+        }
+        // Each half on its own is found, which is the whole point of the note.
+        assert!(
+            grep_tree(&dir, &req("alpha"), None)
+                .unwrap()
+                .contains("a.rs:1:")
+        );
+
+        // Having asked for a regex, an empty result means what it says — the
+        // note would be telling the caller about a choice they already made.
+        let asked = grep_tree(
+            &dir,
+            &GrepReq {
+                pattern: "gamma|delta".into(),
+                regex: Some(true),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+        assert!(asked.contains("no matches"), "{asked}");
+        assert!(!asked.contains("regexp pattern"), "{asked}");
+
+        // A genuine absence stays quiet — the note must not fire on every miss,
+        // or it stops being read.
+        let plain = grep_tree(&dir, &req("gamma"), None).unwrap();
+        assert!(plain.contains("no matches"), "{plain}");
+        assert!(!plain.contains("regexp pattern"), "{plain}");
+        // Nor on a literal that merely contains a paren or a dot.
+        let paren = grep_tree(&dir, &req("gamma(x)"), None).unwrap();
+        assert!(!paren.contains("regexp pattern"), "{paren}");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }
 


### PR DESCRIPTION
`grep` is literal unless `regex` is set, so `a|b` is looked for as those three
characters, finds nothing, and answers `no matches` — the same two words a
genuine miss returns. The two failures are indistinguishable, which is what
turns a mis-typed pattern into "I checked, it isn't there" in a caller's
conclusion.

Observed against this repository, with the tool as it stands today:

```
grep "timeout|retry"  path=crates/dr-strange-llm   → no matches
grep "timeout"        path=crates/dr-strange-llm   → post_with_timeout, REQUEST_TIMEOUT, …
grep "retry"          path=crates/dr-strange-llm   → worth_retrying, the retry schedule, Throttle
```

Both terms are there, abundantly. Together they read as absent.

The one hint the empty case already carried points the other way: dropping
`path` to widen still returns nothing, because the scope was never the problem,
so following it makes the wrong conclusion firmer rather than catching it.

When the result is empty, the pattern carries a construct only a regex would
want, and `regex` was not asked for, this says so once. Having asked, an empty
result means what it says, so the note stays out of the way.

`(`, `[` and a lone `.` are deliberately not tells: they are ordinary in a
literal code search (`TrimPrefix(`), and a hint that cries wolf is a hint that
gets read past.

Nothing else changes — no new parameter, no change to the default, and every
call that matches something, or that passed `regex: true`, returns byte-identical
output. The test pins the three silences as well as the one message.